### PR TITLE
feat: adds custom bootstrap before environment variable mapping

### DIFF
--- a/4/debian-10/rootfs/opt/bitnami/scripts/apache-env.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/apache-env.sh
@@ -11,6 +11,10 @@
 # Load logging library
 . /opt/bitnami/scripts/liblog.sh
 
+if [[ -f "/custom-bootstrap.sh" ]]; then
+    . /custom-bootstrap.sh
+fi
+
 export BITNAMI_ROOT_DIR="/opt/bitnami"
 export BITNAMI_VOLUME_DIR="/bitnami"
 

--- a/4/debian-10/rootfs/opt/bitnami/scripts/matomo-env.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/matomo-env.sh
@@ -11,6 +11,10 @@
 # Load logging library
 . /opt/bitnami/scripts/liblog.sh
 
+if [[ -f "/custom-bootstrap.sh" ]]; then
+    . /custom-bootstrap.sh
+fi
+
 export BITNAMI_ROOT_DIR="/opt/bitnami"
 export BITNAMI_VOLUME_DIR="/bitnami"
 

--- a/4/debian-10/rootfs/opt/bitnami/scripts/mysql-client-env.sh
+++ b/4/debian-10/rootfs/opt/bitnami/scripts/mysql-client-env.sh
@@ -11,6 +11,10 @@
 # Load logging library
 . /opt/bitnami/scripts/liblog.sh
 
+if [[ -f "/custom-bootstrap.sh" ]]; then
+    . /custom-bootstrap.sh
+fi
+
 export BITNAMI_ROOT_DIR="/opt/bitnami"
 export BITNAMI_VOLUME_DIR="/bitnami"
 

--- a/README.md
+++ b/README.md
@@ -517,6 +517,23 @@ volumes:
     driver: local
 ```
 
+If you are using tolling to inject environemnt variables you may want to add a custom bootstrap script. It will be executed before any environment variable mapping.
+
+```sh
+#!/bin/bash
+. /opt/bitnami/scripts/liblog.sh
+
+info "Custom bootstrap loaded"
+```
+
+After this you can add it to your image
+```dockerfile
+FROM bitnami/matomo
+
+COPY ./custom-bootstrap.sh /custom-bootstrap.sh
+```
+
+With that in place you do not need to overwrite `CMD` or `ENTRYPOINT` arguments and fear of missing something out in the future.
 # Notable Changes
 
 ## 3.14.1-debian-10-r79


### PR DESCRIPTION
**Description of the change**

This change adds 3 LOCs to every environment mapping file to load custom environment variables into scope. It is only executed if the operator explicitly added a __/custom-bootstrap.sh__ file.

**Benefits**

People like me operate on a PaaS or CaaS like Cloud Foundry or Kubernetes. With this we are able to load variables from `VCAP_SERVICES ` of cloud foundry or contact a Vault on Kubernetes.

